### PR TITLE
chore: Adding possibility to skip Juju model creation

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -2,95 +2,96 @@
 # See LICENSE file for licensing details.
 
 resource "juju_model" "sdcore" {
-  name = var.model_name
+  count = var.create_model == true ? 1 : 0
+  name  = var.model_name
 }
 
 module "amf" {
   source     = "git::https://github.com/canonical/sdcore-amf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
   config     = var.amf_config
 }
 
 module "ausf" {
   source     = "git::https://github.com/canonical/sdcore-ausf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "nms" {
   source     = "git::https://github.com/canonical/sdcore-nms-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "nrf" {
   source     = "git::https://github.com/canonical/sdcore-nrf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "nssf" {
   source     = "git::https://github.com/canonical/sdcore-nssf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
   config     = var.nssf_config
 }
 
 module "pcf" {
   source     = "git::https://github.com/canonical/sdcore-pcf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "smf" {
   source     = "git::https://github.com/canonical/sdcore-smf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "udm" {
   source     = "git::https://github.com/canonical/sdcore-udm-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "udr" {
   source     = "git::https://github.com/canonical/sdcore-udr-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "webui" {
   source     = "git::https://github.com/canonical/sdcore-webui-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "mongodb" {
   source     = "../mongodb-k8s"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.mongo_channel
   config     = var.mongo_config
 }
 
 module "grafana-agent" {
   source     = "../grafana-agent-k8s"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.grafana_agent_channel
   config     = var.grafana_agent_config
 }
 
 module "self-signed-certificates" {
   source     = "git::https://github.com/canonical/self-signed-certificates-operator.git//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.self_signed_certificates_channel
   config     = var.self_signed_certificates_config
 }
 
 module "traefik" {
   source     = "../traefik-k8s"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.traefik_channel
   config     = var.traefik_config
 }
@@ -98,7 +99,7 @@ module "traefik" {
 # Integrations for `fiveg-nrf` endpoint
 
 resource "juju_integration" "amf-fiveg-nrf" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -112,7 +113,7 @@ resource "juju_integration" "amf-fiveg-nrf" {
 }
 
 resource "juju_integration" "udm-fiveg-nrf" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udm.app_name
@@ -126,7 +127,7 @@ resource "juju_integration" "udm-fiveg-nrf" {
 }
 
 resource "juju_integration" "smf-fiveg-nrf" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -140,7 +141,7 @@ resource "juju_integration" "smf-fiveg-nrf" {
 }
 
 resource "juju_integration" "pcf-fiveg-nrf" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.pcf.app_name
@@ -154,7 +155,7 @@ resource "juju_integration" "pcf-fiveg-nrf" {
 }
 
 resource "juju_integration" "nssf-fiveg-nrf" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nssf.app_name
@@ -168,7 +169,7 @@ resource "juju_integration" "nssf-fiveg-nrf" {
 }
 
 resource "juju_integration" "udr-fiveg-nrf" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udr.app_name
@@ -182,7 +183,7 @@ resource "juju_integration" "udr-fiveg-nrf" {
 }
 
 resource "juju_integration" "ausf-fiveg-nrf" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.ausf.app_name
@@ -198,7 +199,7 @@ resource "juju_integration" "ausf-fiveg-nrf" {
 # Integrations for `database` endpoint
 
 resource "juju_integration" "amf-database" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -212,7 +213,7 @@ resource "juju_integration" "amf-database" {
 }
 
 resource "juju_integration" "udr-database" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udr.app_name
@@ -226,7 +227,7 @@ resource "juju_integration" "udr-database" {
 }
 
 resource "juju_integration" "smf-database" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -240,7 +241,7 @@ resource "juju_integration" "smf-database" {
 }
 
 resource "juju_integration" "pcf-database" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.pcf.app_name
@@ -254,7 +255,7 @@ resource "juju_integration" "pcf-database" {
 }
 
 resource "juju_integration" "nrf-database" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nrf.app_name
@@ -268,7 +269,7 @@ resource "juju_integration" "nrf-database" {
 }
 
 resource "juju_integration" "webui-database" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.webui.app_name
@@ -284,7 +285,7 @@ resource "juju_integration" "webui-database" {
 # Integrations for `metrics` endpoint
 
 resource "juju_integration" "amf-metrics" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -298,7 +299,7 @@ resource "juju_integration" "amf-metrics" {
 }
 
 resource "juju_integration" "smf-metrics" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -312,7 +313,7 @@ resource "juju_integration" "smf-metrics" {
 }
 
 resource "juju_integration" "mongodb-metrics" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.mongodb.app_name
@@ -328,7 +329,7 @@ resource "juju_integration" "mongodb-metrics" {
 # Integrations for `certificates` endpoint
 
 resource "juju_integration" "amf-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -342,7 +343,7 @@ resource "juju_integration" "amf-certificates" {
 }
 
 resource "juju_integration" "udm-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udm.app_name
@@ -356,7 +357,7 @@ resource "juju_integration" "udm-certificates" {
 }
 
 resource "juju_integration" "smf-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -370,7 +371,7 @@ resource "juju_integration" "smf-certificates" {
 }
 
 resource "juju_integration" "pcf-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.pcf.app_name
@@ -384,7 +385,7 @@ resource "juju_integration" "pcf-certificates" {
 }
 
 resource "juju_integration" "nssf-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nssf.app_name
@@ -398,7 +399,7 @@ resource "juju_integration" "nssf-certificates" {
 }
 
 resource "juju_integration" "nrf-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nrf.app_name
@@ -412,7 +413,7 @@ resource "juju_integration" "nrf-certificates" {
 }
 
 resource "juju_integration" "ausf-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.ausf.app_name
@@ -426,7 +427,7 @@ resource "juju_integration" "ausf-certificates" {
 }
 
 resource "juju_integration" "udr-certificates" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udr.app_name
@@ -442,7 +443,7 @@ resource "juju_integration" "udr-certificates" {
 # Integrations for `ingress` endpoint
 
 resource "juju_integration" "nms-ingress" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nms.app_name
@@ -458,7 +459,7 @@ resource "juju_integration" "nms-ingress" {
 # Integrations for `sdcore-management` endpoint
 
 resource "juju_integration" "nms-sdcore-management" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nms.app_name
@@ -474,7 +475,7 @@ resource "juju_integration" "nms-sdcore-management" {
 # Integrations for `logging` endpoint
 
 resource "juju_integration" "mongodb-logging" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.mongodb.app_name

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -7,6 +7,12 @@ variable "model_name" {
   default     = ""
 }
 
+variable "create_model" {
+  description = "Allows to skip Juju model creation and re-use a model created in a higher level module."
+  type        = bool
+  default     = true
+}
+
 variable "channel" {
   description = "The channel to use when deploying `SD-Core` charms."
   type        = string

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -2,102 +2,103 @@
 # See LICENSE file for licensing details.
 
 resource "juju_model" "sdcore" {
+  count = var.create_model == true ? 1 : 0
   name = var.model_name
 }
 
 module "amf" {
   source     = "git::https://github.com/canonical/sdcore-amf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
   config     = var.amf_config
 }
 
 module "ausf" {
   source     = "git::https://github.com/canonical/sdcore-ausf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "nms" {
   source     = "git::https://github.com/canonical/sdcore-nms-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "nrf" {
   source     = "git::https://github.com/canonical/sdcore-nrf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "nssf" {
   source     = "git::https://github.com/canonical/sdcore-nssf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
   config     = var.nssf_config
 }
 
 module "pcf" {
   source     = "git::https://github.com/canonical/sdcore-pcf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "smf" {
   source     = "git::https://github.com/canonical/sdcore-smf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "udm" {
   source     = "git::https://github.com/canonical/sdcore-udm-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "udr" {
   source     = "git::https://github.com/canonical/sdcore-udr-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "webui" {
   source     = "git::https://github.com/canonical/sdcore-webui-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
 }
 
 module "mongodb" {
   source     = "../mongodb-k8s"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.mongo_channel
   config     = var.mongo_config
 }
 
 module "grafana-agent" {
   source     = "../grafana-agent-k8s"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.grafana_agent_channel
   config     = var.grafana_agent_config
 }
 
 module "self-signed-certificates" {
   source     = "git::https://github.com/canonical/self-signed-certificates-operator.git//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.self_signed_certificates_channel
   config     = var.self_signed_certificates_config
 }
 
 module "traefik" {
   source     = "../traefik-k8s"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.traefik_channel
   config     = var.traefik_config
 }
 
 module "upf" {
   source     = "git::https://github.com/canonical/sdcore-upf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
   config     = var.upf_config
 }
@@ -105,7 +106,7 @@ module "upf" {
 # Integrations for `fiveg-nrf` endpoint
 
 resource "juju_integration" "amf-fiveg-nrf" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -119,7 +120,7 @@ resource "juju_integration" "amf-fiveg-nrf" {
 }
 
 resource "juju_integration" "udm-fiveg-nrf" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udm.app_name
@@ -133,7 +134,7 @@ resource "juju_integration" "udm-fiveg-nrf" {
 }
 
 resource "juju_integration" "smf-fiveg-nrf" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -147,7 +148,7 @@ resource "juju_integration" "smf-fiveg-nrf" {
 }
 
 resource "juju_integration" "pcf-fiveg-nrf" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.pcf.app_name
@@ -161,7 +162,7 @@ resource "juju_integration" "pcf-fiveg-nrf" {
 }
 
 resource "juju_integration" "nssf-fiveg-nrf" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nssf.app_name
@@ -175,7 +176,7 @@ resource "juju_integration" "nssf-fiveg-nrf" {
 }
 
 resource "juju_integration" "udr-fiveg-nrf" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udr.app_name
@@ -189,7 +190,7 @@ resource "juju_integration" "udr-fiveg-nrf" {
 }
 
 resource "juju_integration" "ausf-fiveg-nrf" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.ausf.app_name
@@ -205,7 +206,7 @@ resource "juju_integration" "ausf-fiveg-nrf" {
 # Integrations for `database` endpoint
 
 resource "juju_integration" "amf-database" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -219,7 +220,7 @@ resource "juju_integration" "amf-database" {
 }
 
 resource "juju_integration" "udr-database" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udr.app_name
@@ -233,7 +234,7 @@ resource "juju_integration" "udr-database" {
 }
 
 resource "juju_integration" "smf-database" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -247,7 +248,7 @@ resource "juju_integration" "smf-database" {
 }
 
 resource "juju_integration" "pcf-database" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.pcf.app_name
@@ -261,7 +262,7 @@ resource "juju_integration" "pcf-database" {
 }
 
 resource "juju_integration" "nrf-database" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nrf.app_name
@@ -275,7 +276,7 @@ resource "juju_integration" "nrf-database" {
 }
 
 resource "juju_integration" "webui-database" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.webui.app_name
@@ -291,7 +292,7 @@ resource "juju_integration" "webui-database" {
 # Integrations for `metrics` endpoint
 
 resource "juju_integration" "amf-metrics" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -305,7 +306,7 @@ resource "juju_integration" "amf-metrics" {
 }
 
 resource "juju_integration" "smf-metrics" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -319,7 +320,7 @@ resource "juju_integration" "smf-metrics" {
 }
 
 resource "juju_integration" "mongodb-metrics" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.mongodb.app_name
@@ -333,7 +334,7 @@ resource "juju_integration" "mongodb-metrics" {
 }
 
 resource "juju_integration" "upf-metrics" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.upf.app_name
@@ -349,7 +350,7 @@ resource "juju_integration" "upf-metrics" {
 # Integrations for `certificates` endpoint
 
 resource "juju_integration" "amf-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.amf.app_name
@@ -363,7 +364,7 @@ resource "juju_integration" "amf-certificates" {
 }
 
 resource "juju_integration" "udm-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udm.app_name
@@ -377,7 +378,7 @@ resource "juju_integration" "udm-certificates" {
 }
 
 resource "juju_integration" "smf-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.smf.app_name
@@ -391,7 +392,7 @@ resource "juju_integration" "smf-certificates" {
 }
 
 resource "juju_integration" "pcf-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.pcf.app_name
@@ -405,7 +406,7 @@ resource "juju_integration" "pcf-certificates" {
 }
 
 resource "juju_integration" "nssf-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nssf.app_name
@@ -419,7 +420,7 @@ resource "juju_integration" "nssf-certificates" {
 }
 
 resource "juju_integration" "nrf-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nrf.app_name
@@ -433,7 +434,7 @@ resource "juju_integration" "nrf-certificates" {
 }
 
 resource "juju_integration" "ausf-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.ausf.app_name
@@ -447,7 +448,7 @@ resource "juju_integration" "ausf-certificates" {
 }
 
 resource "juju_integration" "udr-certificates" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.udr.app_name
@@ -463,7 +464,7 @@ resource "juju_integration" "udr-certificates" {
 # Integrations for `ingress` endpoint
 
 resource "juju_integration" "nms-ingress" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nms.app_name
@@ -479,7 +480,7 @@ resource "juju_integration" "nms-ingress" {
 # Integrations for `sdcore-management` endpoint
 
 resource "juju_integration" "nms-sdcore-management" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.nms.app_name
@@ -495,7 +496,7 @@ resource "juju_integration" "nms-sdcore-management" {
 # Integrations for `logging` endpoint
 
 resource "juju_integration" "mongodb-logging" {
-  model = juju_model.sdcore.name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.mongodb.app_name

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -7,6 +7,12 @@ variable "model_name" {
   default     = ""
 }
 
+variable "create_model" {
+  description = "Allows to skip Juju model creation and re-use a model created in a higher level module."
+  type        = bool
+  default     = true
+}
+
 variable "channel" {
   description = "The channel to use when deploying `SD-Core` charms."
   type        = string

--- a/modules/sdcore-user-plane-k8s/main.tf
+++ b/modules/sdcore-user-plane-k8s/main.tf
@@ -2,19 +2,20 @@
 # See LICENSE file for licensing details.
 
 resource "juju_model" "sdcore" {
+  count = var.create_model == true ? 1 : 0
   name = var.model_name
 }
 
 module "upf" {
   source     = "git::https://github.com/canonical/sdcore-upf-k8s-operator//terraform"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.channel
   config     = var.upf_config
 }
 
 module "grafana-agent" {
   source     = "../grafana-agent-k8s"
-  model_name = juju_model.sdcore.name
+  model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
   channel    = var.grafana_agent_channel
   config     = var.grafana_agent_config
 }
@@ -22,7 +23,7 @@ module "grafana-agent" {
 # Integrations for `metrics` endpoint
 
 resource "juju_integration" "upf-metrics" {
-  model = var.model_name
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
 
   application {
     name     = module.upf.app_name

--- a/modules/sdcore-user-plane-k8s/variables.tf
+++ b/modules/sdcore-user-plane-k8s/variables.tf
@@ -7,6 +7,12 @@ variable "model_name" {
   default     = ""
 }
 
+variable "create_model" {
+  description = "Allows to skip Juju model creation and re-use a model created in a higher level module."
+  type        = bool
+  default     = true
+}
+
 variable "channel" {
   description = "The channel to use when deploying `SD-Core` charms."
   type        = string


### PR DESCRIPTION
# Description

When building Terraform modules, we will sometimes need to create a Juju model prior to deploying SD-Core (i.e. integration tests - we need to deploy SD-Core router before the rest of the SD-Core). In such cases, Terraform would fail trying to create the same model twice. 
This PR allows to skip Juju model creation and re-using of an existing model passed through a variable.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library