### PR TITLE
fix: Adding fiveg_n4 relation between the NMS and the UPF

### DIFF
--- a/modules/sdcore-control-plane-k8s/outputs.tf
+++ b/modules/sdcore-control-plane-k8s/outputs.tf
@@ -16,6 +16,11 @@ output "nms_app_name" {
   value       = module.nms.app_name
 }
 
+output "fiveg_n4_endpoint" {
+  description = "Name of the endpoint to integrate with fiveg_n4 interface."
+  value       = module.nms.fiveg_n4_endpoint
+}
+
 output "fiveg_gnb_identity_endpoint" {
   description = "Name of the endpoint to integrate with fiveg_gnb_identity interface."
   value       = module.nms.fiveg_gnb_identity_endpoint

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -508,3 +508,19 @@ resource "juju_integration" "mongodb-logging" {
     endpoint = module.grafana-agent.logging_provider_endpoint
   }
 }
+
+# Integrations for `fiveg-n4` endpoint
+
+resource "juju_integration" "upf-nms" {
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
+
+  application {
+    name     = module.upf.app_name
+    endpoint = module.upf.fiveg_n4_endpoint
+  }
+
+  application {
+    name     = module.nms.app_name
+    endpoint = module.nms.fiveg_n4_endpoint
+  }
+}


### PR DESCRIPTION
# Description

- Adds missing relation between the NMS and the UPF
- Exposes `fiveg_n4` endpoint from CP module

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library