### PR TITLE
feat: Adding support for multiple clouds hosted on the same controller

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -4,6 +4,10 @@
 resource "juju_model" "sdcore" {
   count = var.create_model == true ? 1 : 0
   name  = var.model_name
+
+  cloud {
+    name = var.cloud_name
+  }
 }
 
 module "amf" {

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -7,6 +7,12 @@ variable "model_name" {
   default     = ""
 }
 
+variable "cloud_name" {
+  description = "Name of the Juju cloud to create Juju model on."
+  type        = string
+  default     = "microk8s"
+}
+
 variable "create_model" {
   description = "Allows to skip Juju model creation and re-use a model created in a higher level module."
   type        = bool

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -4,6 +4,10 @@
 resource "juju_model" "sdcore" {
   count = var.create_model == true ? 1 : 0
   name  = var.model_name
+
+  cloud {
+    name = var.cloud_name
+  }
 }
 
 module "amf" {

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -7,6 +7,12 @@ variable "model_name" {
   default     = ""
 }
 
+variable "cloud_name" {
+  description = "Name of the Juju cloud to create Juju model on."
+  type        = string
+  default     = "microk8s"
+}
+
 variable "create_model" {
   description = "Allows to skip Juju model creation and re-use a model created in a higher level module."
   type        = bool

--- a/modules/sdcore-user-plane-k8s/main.tf
+++ b/modules/sdcore-user-plane-k8s/main.tf
@@ -4,6 +4,10 @@
 resource "juju_model" "sdcore" {
   count = var.create_model == true ? 1 : 0
   name  = var.model_name
+
+  cloud {
+    name = var.cloud_name
+  }
 }
 
 module "upf" {

--- a/modules/sdcore-user-plane-k8s/variables.tf
+++ b/modules/sdcore-user-plane-k8s/variables.tf
@@ -7,6 +7,12 @@ variable "model_name" {
   default     = ""
 }
 
+variable "cloud_name" {
+  description = "Name of the Juju cloud to create Juju model on."
+  type        = string
+  default     = "microk8s"
+}
+
 variable "create_model" {
   description = "Allows to skip Juju model creation and re-use a model created in a higher level module."
   type        = bool


### PR DESCRIPTION
# Description

Adds support for multiple clouds hosted on the same controller.
Use case: https://canonical-charmed-5g.readthedocs-hosted.com/en/latest/tutorials/mastering/

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library