### PR TITLE
fix: Reverting exposure of the model name from sdcore modules

### DIFF
--- a/modules/sdcore-control-plane-k8s/outputs.tf
+++ b/modules/sdcore-control-plane-k8s/outputs.tf
@@ -1,11 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-output "model_name" {
-  description = "Name of the Juju model used for the deployment."
-  value       = juju_model.sdcore.name
-}
-
 output "amf_app_name" {
   description = "Name of the deployed AMF application."
   value       = module.amf.app_name

--- a/modules/sdcore-k8s/outputs.tf
+++ b/modules/sdcore-k8s/outputs.tf
@@ -1,11 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-output "model_name" {
-  description = "Name of the Juju model used for the deployment."
-  value       = juju_model.sdcore.name
-}
-
 output "amf_app_name" {
   description = "Name of the deployed AMF application."
   value       = module.amf.app_name

--- a/modules/sdcore-user-plane-k8s/outputs.tf
+++ b/modules/sdcore-user-plane-k8s/outputs.tf
@@ -1,11 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-output "model_name" {
-  description = "Name of the Juju model used for the deployment."
-  value       = juju_model.sdcore.name
-}
-
 output "upf_app_name" {
   description = "Name of the deployed UPF application."
   value       = module.upf.app_name


### PR DESCRIPTION
# Description

Reverts changes from https://github.com/canonical/terraform-juju-sdcore-k8s/pull/9

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library