### PR TITLE
fix: Update READMEs for the modules

### DIFF
--- a/modules/sdcore-control-plane-k8s/README.md
+++ b/modules/sdcore-control-plane-k8s/README.md
@@ -79,16 +79,10 @@ model_name = "put your model-name here"
 EOF
 ```
 
-Create the Terraform Plan:
-
-```console
-terraform plan -var-file="terraform.tfvars" 
-```
-
 Deploy the resources:
 
 ```console
-terraform apply -auto-approve 
+terraform apply -var-file="terraform.tfvars" -auto-approve 
 ```
 
 #### Including Canonical Observability Stack (COS)

--- a/modules/sdcore-k8s/README.md
+++ b/modules/sdcore-k8s/README.md
@@ -80,16 +80,10 @@ model_name = "put your model-name here"
 EOF
 ```
 
-Create the Terraform Plan:
-
-```console
-terraform plan -var-file="terraform.tfvars" 
-```
-
 Deploy the resources:
 
 ```console
-terraform apply -auto-approve 
+terraform apply -var-file="terraform.tfvars" -auto-approve 
 ```
 
 #### Including Canonical Observability Stack (COS)

--- a/modules/sdcore-user-plane-k8s/README.md
+++ b/modules/sdcore-user-plane-k8s/README.md
@@ -80,16 +80,10 @@ model_name = "put your model-name here"
 EOF
 ```
 
-Create the Terraform Plan:
-
-```console
-terraform plan -var-file="terraform.tfvars" 
-```
-
 Deploy the resources:
 
 ```console
-terraform apply -auto-approve 
+terraform apply -var-file="terraform.tfvars" -auto-approve 
 ```
 
 #### Including Canonical Observability Stack (COS)


### PR DESCRIPTION
# Description

Updates READMEs for the SD-Core modules to pass the `-var-file` directly to `terraform apply`.
If the plan generated with `terraform plan` is not saved and passed to `terraform apply`, the `tfvars` file will be ignored and the deployment fails. Passing the `tfvars` file to `terraform apply` directly, eliminates a need of saving the plan.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library