### PR TITLE
fix: Fixing grafana-agent endpoint for logging integration in sdcore-user-plane-k8s

### DIFF
--- a/modules/sdcore-user-plane-k8s/main.tf
+++ b/modules/sdcore-user-plane-k8s/main.tf
@@ -56,7 +56,7 @@ resource "juju_integration" "upf-logging" {
 
   application {
     name     = module.grafana-agent.app_name
-    endpoint = module.grafana-agent.logging_consumer_endpoint
+    endpoint = module.grafana-agent.logging_provider_endpoint
   }
 }
 


### PR DESCRIPTION
# Description

Fixes logging endpoint on grafana-agent end of the `upf-logging` integration.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library