### PR TITLE
chore: Bumping version of the Terraform provider

### DIFF
--- a/modules/external/alertmanager-k8s/terraform.tf
+++ b/modules/external/alertmanager-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/catalogue-k8s/terraform.tf
+++ b/modules/external/catalogue-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/cos-configuration-k8s/terraform.tf
+++ b/modules/external/cos-configuration-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/cos-lite/terraform.tf
+++ b/modules/external/cos-lite/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/grafana-agent-k8s/terraform.tf
+++ b/modules/external/grafana-agent-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/grafana-k8s/terraform.tf
+++ b/modules/external/grafana-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/loki-k8s/terraform.tf
+++ b/modules/external/loki-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/mongodb-k8s/terraform.tf
+++ b/modules/external/mongodb-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/prometheus-k8s/terraform.tf
+++ b/modules/external/prometheus-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/external/traefik-k8s/terraform.tf
+++ b/modules/external/traefik-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/sdcore-control-plane-k8s/terraform.tf
+++ b/modules/sdcore-control-plane-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/sdcore-control-plane-k8s/terraform.tf
+++ b/modules/sdcore-control-plane-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = ">= 0.10.1"
     }
   }
 }

--- a/modules/sdcore-k8s/terraform.tf
+++ b/modules/sdcore-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/sdcore-user-plane-k8s/terraform.tf
+++ b/modules/sdcore-user-plane-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.10.1"
+      version = "~> 0.11.0"
     }
   }
 }

--- a/modules/sdcore-user-plane-k8s/terraform.tf
+++ b/modules/sdcore-user-plane-k8s/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.10.1"
+      version = ">= 0.10.1"
     }
   }
 }


### PR DESCRIPTION
# Description

Bumps version of the Terraform provider to `0.11.0`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library