### PR TITLE
fix: Adding the track to the default channels

### DIFF
--- a/modules/external/alertmanager-k8s/variables.tf
+++ b/modules/external/alertmanager-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "Channel to use when deploying a charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 
 variable "config" {

--- a/modules/external/catalogue-k8s/variables.tf
+++ b/modules/external/catalogue-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 
 variable "config" {

--- a/modules/external/cos-configuration-k8s/variables.tf
+++ b/modules/external/cos-configuration-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 
 variable "config" {

--- a/modules/external/cos-lite/variables.tf
+++ b/modules/external/cos-lite/variables.tf
@@ -16,7 +16,7 @@ variable "alertmanager_app_name" {
 variable "alertmanager_channel" {
   description = "The channel to use when deploying Alertmanager charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 variable "alertmanager_config" {
   description = "Application config. Details about available options can be found at https://charmhub.io/alertmanager-k8s/configure."
@@ -33,7 +33,7 @@ variable "catalogue_app_name" {
 variable "catalogue_channel" {
   description = "The channel to use when deploying Catalogue charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 variable "catalogue_config" {
   description = "Catalogue config. Details about available options can be found at https://charmhub.io/catalogue-k8s/configure."
@@ -55,7 +55,7 @@ variable "cos_configuration_app_name" {
 variable "cos_configuration_channel" {
   description = "The channel to use when deploying cos-configuration-k8s charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 variable "cos_configuration_config" {
   description = "COS Configuration application config. Details about available options can be found at https://charmhub.io/cos-configuration-k8s/configure."
@@ -72,7 +72,7 @@ variable "grafana_app_name" {
 variable "grafana_channel" {
   description = "The channel to use when deploying Grafana charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 variable "grafana_config" {
   description = "Grafana config. Details about available options can be found at https://charmhub.io/grafana-k8s/configure."
@@ -89,7 +89,7 @@ variable "loki_app_name" {
 variable "loki_channel" {
   description = "The channel to use when deploying Loki charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 variable "loki_config" {
   description = "Loki config. Details about available options can be found at https://charmhub.io/loki-k8s/configure."
@@ -106,7 +106,7 @@ variable "prometheus_app_name" {
 variable "prometheus_channel" {
   description = "The channel to use when deploying Prometheus charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 variable "prometheus_config" {
   description = "Application config. Details about available options can be found at https://charmhub.io/prometheus-k8s/configure."
@@ -123,7 +123,7 @@ variable "traefik_app_name" {
 variable "traefik_channel" {
   description = "The channel to use when deploying Traefik charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 variable "traefik_config" {
   description = "Traefik config. Details about available options can be found at https://charmhub.io/traefik-k8s/configure."

--- a/modules/external/grafana-k8s/variables.tf
+++ b/modules/external/grafana-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "Channel to use when deploying a charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 
 variable "config" {

--- a/modules/external/loki-k8s/variables.tf
+++ b/modules/external/loki-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 
 variable "config" {

--- a/modules/external/prometheus-k8s/variables.tf
+++ b/modules/external/prometheus-k8s/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "stable"
+  default     = "latest/stable"
 }
 
 variable "config" {

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -34,7 +34,7 @@ variable "grafana_agent_channel" {
 variable "self_signed_certificates_channel" {
   description = "The channel to use when deploying `self-signed-certificates-operator` charm."
   type        = string
-  default     = "beta"
+  default     = "latest/beta"
 }
 
 variable "traefik_channel" {

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -68,7 +68,7 @@ variable "mongo_config" {
 variable "self_signed_certificates_channel" {
   description = "The channel to use when deploying `self-signed-certificates-operator` charm."
   type        = string
-  default     = "beta"
+  default     = "latest/beta"
 }
 variable "self_signed_certificates_config" {
   description = "Additional configuration for the Self-Signed-Certificates. Details about available options can be found at https://charmhub.io/self-signed-certificates-operator/configure."


### PR DESCRIPTION
# Description

Changes in this PR are a workaround for the
```
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to module.self-signed-certificates.juju_application.self-signed-certificates, provider "provider[\"registry.terraform.io/juju/juju\"]" produced an unexpected new value: .charm[0].channel: was
│ cty.StringVal("beta"), but now cty.StringVal("latest/beta").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

Bug report created to track the issue: https://github.com/juju/terraform-provider-juju/issues/445

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library