### PR TITLE
chore: use release version of github workflows

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -10,5 +10,5 @@ on:
 jobs:
   update:
     name: Update Issue
-    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v0.0.1
     secrets: inherit

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   check-terraform-module:
     name: Check Terraform Module
-    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/terraform.yaml@v0.0.1
     secrets: inherit
     with:
       working-directory: ./modules


### PR DESCRIPTION
# Description

We use the release version of CI workflow instead of pointing to main. This prevents updates to the workflow causing the CI to fail here.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library