### PR TITLE
chore: Rolling back to a single channel variable for SD-Core charms

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -9,63 +9,63 @@ resource "juju_model" "sdcore" {
 module "amf" {
   source     = "git::https://github.com/canonical/sdcore-amf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.amf_channel
+  channel    = var.sdcore_channel
   config     = var.amf_config
 }
 
 module "ausf" {
   source     = "git::https://github.com/canonical/sdcore-ausf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.ausf_channel
+  channel    = var.sdcore_channel
 }
 
 module "nms" {
   source     = "git::https://github.com/canonical/sdcore-nms-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.nms_channel
+  channel    = var.sdcore_channel
 }
 
 module "nrf" {
   source     = "git::https://github.com/canonical/sdcore-nrf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.nrf_channel
+  channel    = var.sdcore_channel
 }
 
 module "nssf" {
   source     = "git::https://github.com/canonical/sdcore-nssf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.nssf_channel
+  channel    = var.sdcore_channel
   config     = var.nssf_config
 }
 
 module "pcf" {
   source     = "git::https://github.com/canonical/sdcore-pcf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.pcf_channel
+  channel    = var.sdcore_channel
 }
 
 module "smf" {
   source     = "git::https://github.com/canonical/sdcore-smf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.smf_channel
+  channel    = var.sdcore_channel
 }
 
 module "udm" {
   source     = "git::https://github.com/canonical/sdcore-udm-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.udm_channel
+  channel    = var.sdcore_channel
 }
 
 module "udr" {
   source     = "git::https://github.com/canonical/sdcore-udr-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.udr_channel
+  channel    = var.sdcore_channel
 }
 
 module "webui" {
   source     = "git::https://github.com/canonical/sdcore-webui-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.webui_channel
+  channel    = var.sdcore_channel
 }
 
 module "mongodb" {

--- a/modules/sdcore-control-plane-k8s/variables.tf
+++ b/modules/sdcore-control-plane-k8s/variables.tf
@@ -13,62 +13,8 @@ variable "create_model" {
   default     = true
 }
 
-variable "amf_channel" {
-  description = "The channel to use when deploying `sdcore-amf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "ausf_channel" {
-  description = "The channel to use when deploying `sdcore-ausf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "nms_channel" {
-  description = "The channel to use when deploying `sdcore-nms-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "nrf_channel" {
-  description = "The channel to use when deploying `sdcore-nrf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "nssf_channel" {
-  description = "The channel to use when deploying `sdcore-nssf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "pcf_channel" {
-  description = "The channel to use when deploying `sdcore-pcf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "smf_channel" {
-  description = "The channel to use when deploying `sdcore-smf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "udm_channel" {
-  description = "The channel to use when deploying `sdcore-udm-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "udr_channel" {
-  description = "The channel to use when deploying `sdcore-udr-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "webui_channel" {
-  description = "The channel to use when deploying `sdcore-webui-k8s` charm."
+variable "sdcore_channel" {
+  description = "The channel to use when deploying Charmed Aether SD-Core charms."
   type        = string
   default     = "1.4/edge"
 }

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -9,63 +9,63 @@ resource "juju_model" "sdcore" {
 module "amf" {
   source     = "git::https://github.com/canonical/sdcore-amf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.amf_channel
+  channel    = var.sdcore_channel
   config     = var.amf_config
 }
 
 module "ausf" {
   source     = "git::https://github.com/canonical/sdcore-ausf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.ausf_channel
+  channel    = var.sdcore_channel
 }
 
 module "nms" {
   source     = "git::https://github.com/canonical/sdcore-nms-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.nms_channel
+  channel    = var.sdcore_channel
 }
 
 module "nrf" {
   source     = "git::https://github.com/canonical/sdcore-nrf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.nrf_channel
+  channel    = var.sdcore_channel
 }
 
 module "nssf" {
   source     = "git::https://github.com/canonical/sdcore-nssf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.nssf_channel
+  channel    = var.sdcore_channel
   config     = var.nssf_config
 }
 
 module "pcf" {
   source     = "git::https://github.com/canonical/sdcore-pcf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.pcf_channel
+  channel    = var.sdcore_channel
 }
 
 module "smf" {
   source     = "git::https://github.com/canonical/sdcore-smf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.smf_channel
+  channel    = var.sdcore_channel
 }
 
 module "udm" {
   source     = "git::https://github.com/canonical/sdcore-udm-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.udm_channel
+  channel    = var.sdcore_channel
 }
 
 module "udr" {
   source     = "git::https://github.com/canonical/sdcore-udr-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.udr_channel
+  channel    = var.sdcore_channel
 }
 
 module "webui" {
   source     = "git::https://github.com/canonical/sdcore-webui-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.webui_channel
+  channel    = var.sdcore_channel
 }
 
 module "mongodb" {
@@ -99,7 +99,7 @@ module "traefik" {
 module "upf" {
   source     = "git::https://github.com/canonical/sdcore-upf-k8s-operator//terraform"
   model_name = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
-  channel    = var.upf_channel
+  channel    = var.sdcore_channel
   config     = var.upf_config
 }
 

--- a/modules/sdcore-k8s/variables.tf
+++ b/modules/sdcore-k8s/variables.tf
@@ -13,68 +13,8 @@ variable "create_model" {
   default     = true
 }
 
-variable "amf_channel" {
-  description = "The channel to use when deploying `sdcore-amf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "ausf_channel" {
-  description = "The channel to use when deploying `sdcore-ausf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "nms_channel" {
-  description = "The channel to use when deploying `sdcore-nms-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "nrf_channel" {
-  description = "The channel to use when deploying `sdcore-nrf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "nssf_channel" {
-  description = "The channel to use when deploying `sdcore-nssf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "pcf_channel" {
-  description = "The channel to use when deploying `sdcore-pcf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "smf_channel" {
-  description = "The channel to use when deploying `sdcore-smf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "udm_channel" {
-  description = "The channel to use when deploying `sdcore-udm-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "udr_channel" {
-  description = "The channel to use when deploying `sdcore-udr-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "upf_channel" {
-  description = "The channel to use when deploying `sdcore-upf-k8s` charm."
-  type        = string
-  default     = "1.4/edge"
-}
-
-variable "webui_channel" {
-  description = "The channel to use when deploying `sdcore-webui-k8s` charm."
+variable "sdcore_channel" {
+  description = "The channel to use when deploying Charmed Aether SD-Core charms."
   type        = string
   default     = "1.4/edge"
 }

--- a/modules/sdcore-user-plane-k8s/variables.tf
+++ b/modules/sdcore-user-plane-k8s/variables.tf
@@ -14,7 +14,7 @@ variable "create_model" {
 }
 
 variable "upf_channel" {
-  description = "The channel to use when deploying `upf-k8s` charm."
+  description = "The channel to use when deploying `sdcore-upf-k8s` charm."
   type        = string
   default     = "1.4/edge"
 }


### PR DESCRIPTION
# Description

Uses a single channel variable for SD-Core charms

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library