### PR TITLE
chore: Adds sdcore_config integration for NRF and SMF

### DIFF
--- a/modules/sdcore-control-plane-k8s/main.tf
+++ b/modules/sdcore-control-plane-k8s/main.tf
@@ -334,6 +334,34 @@ resource "juju_integration" "ausf-sdcore-config" {
   }
 }
 
+resource "juju_integration" "nrf-sdcore-config" {
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
+
+  application {
+    name     = module.nrf.app_name
+    endpoint = module.nrf.sdcore_config_endpoint
+  }
+
+  application {
+    name     = module.webui.app_name
+    endpoint = module.webui.sdcore_config_endpoint
+  }
+}
+
+resource "juju_integration" "smf-sdcore-config" {
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
+
+  application {
+    name     = module.smf.app_name
+    endpoint = module.smf.sdcore_config_endpoint
+  }
+
+  application {
+    name     = module.webui.app_name
+    endpoint = module.webui.sdcore_config_endpoint
+  }
+}
+
 # Integrations for `metrics` endpoint
 
 resource "juju_integration" "amf-metrics" {

--- a/modules/sdcore-k8s/main.tf
+++ b/modules/sdcore-k8s/main.tf
@@ -341,6 +341,34 @@ resource "juju_integration" "ausf-sdcore-config" {
   }
 }
 
+resource "juju_integration" "nrf-sdcore-config" {
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
+
+  application {
+    name     = module.nrf.app_name
+    endpoint = module.nrf.sdcore_config_endpoint
+  }
+
+  application {
+    name     = module.webui.app_name
+    endpoint = module.webui.sdcore_config_endpoint
+  }
+}
+
+resource "juju_integration" "smf-sdcore-config" {
+  model = var.create_model == true ? juju_model.sdcore[0].name : var.model_name
+
+  application {
+    name     = module.smf.app_name
+    endpoint = module.smf.sdcore_config_endpoint
+  }
+
+  application {
+    name     = module.webui.app_name
+    endpoint = module.webui.sdcore_config_endpoint
+  }
+}
+
 # Integrations for `metrics` endpoint
 
 resource "juju_integration" "amf-metrics" {


### PR DESCRIPTION
# Description

Adds `sdcore_config` integration for NRF and SMF

Should be merged after [SMF #226](https://github.com/canonical/sdcore-smf-k8s-operator/pull/226) and [NRF #238](https://github.com/canonical/sdcore-nrf-k8s-operator/pull/238)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library